### PR TITLE
Add logic for applying attributes to children of Field component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'import/core-modules': ['react', 'prop-types', 'react-dom'],
   },
   rules: {
+    'function-paren-newline': 'off',
     'arrow-parens': 'off',
     'react/no-danger': 'off',
     'import/no-named-as-default': 'off',

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -6,16 +6,56 @@ import Input from './Input';
 import Textarea from './Textarea';
 import Select from './Select';
 
+const isLabel = (child) => child.type.displayName === Label.displayName;
+const isFormField = (child) => {
+  if (child.type.displayName === Input.displayName
+    || child.type.displayName === Textarea.displayName
+    || child.type.displayName === Select.displayName) {
+    return true;
+  }
+  return false;
+};
+
+const applyNameAs = (child, nameAs) => {
+  if (!nameAs) {
+    return child;
+  }
+
+  if (isLabel(child)) {
+    return React.cloneElement(child, Object.assign({
+      htmlFor: nameAs,
+    }, child.props));
+  }
+
+  if (isFormField(child)) {
+    return React.cloneElement(child, Object.assign({
+      id: nameAs,
+      name: nameAs,
+    }, child.props));
+  }
+  return child;
+}
+
 export const Field = (props) => {
-  const { tag: Tag, stack, ...rest } = props;
+  const {
+    tag: Tag,
+    nameAs,
+    children,
+    stack,
+    ...rest
+  } = props;
   return (
-    <Tag {...rest} />
+    <Tag {...rest}>
+      {React.Children.map(children, (child) => applyNameAs(child, nameAs))}
+    </Tag>
   );
 };
 
 Field.propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   stack: PropTypes.bool,
+  children: PropTypes.node,
+  nameAs: PropTypes.string,
 };
 
 Field.defaultProps = {

--- a/src/components/__tests__/Field.test.js
+++ b/src/components/__tests__/Field.test.js
@@ -1,0 +1,197 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import 'jest-styled-components';
+import Field, { Field as Raw } from '../Field';
+import Label from '../Label';
+import Input from '../Input';
+import Textarea from '../Textarea';
+import Select from '../Select';
+
+it('should render', () => {
+  const component = renderer.create(<Field />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('should render as stack', () => {
+  const component = renderer.create(<Field stack />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('should render children', () => {
+  const wrapper = shallow(<Raw>Test</Raw>);
+
+  expect(wrapper.text()).toBe('Test');
+});
+
+it('should render additional props', () => {
+  const wrapper = shallow(<Raw data-test="my-attribute" />);
+
+  expect(wrapper.find('[data-test="my-attribute"]')).toHaveLength(1);
+});
+
+it('should display additional classes', () => {
+  const wrapper = shallow(<Raw className="my-class" />);
+
+  expect(wrapper.hasClass('my-class')).toBe(true);
+});
+
+it('should render as a <div> by default', () => {
+  const wrapper = shallow(<Raw />);
+
+  expect(wrapper.type()).toBe('div');
+});
+
+it('should render with a custom tag', () => {
+  const wrapper = shallow(<Raw tag="span" />);
+
+  expect(wrapper.type()).toBe('span');
+});
+
+describe('nameAs', () => {
+  it('should apply the htmlFor attribute to <Label />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Label>Label</Label>
+      </Raw>,
+    );
+
+    expect(wrapper.find(Label).props().htmlFor).toBe('foo');
+  });
+
+  it('should preserve custom htmlFor on <Label />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Label htmlFor="bar">Label</Label>
+      </Raw>,
+    );
+
+    expect(wrapper.find(Label).props().htmlFor).toBe('bar');
+  });
+
+  it('should apply the id attribute to <Input />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Input />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Input).props().id).toBe('foo');
+  });
+
+  it('should preserve custom id on <Input />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Input id="bar" />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Input).props().id).toBe('bar');
+  });
+
+  it('should apply the name attribute to <Input />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Input />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Input).props().name).toBe('foo');
+  });
+
+  it('should preserve custom name on <Input />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Input name="bar" />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Input).props().name).toBe('bar');
+  });
+
+  it('should apply the id attribute to <Textarea />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Textarea />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Textarea).props().id).toBe('foo');
+  });
+
+  it('should preserve custom id on <Textarea />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Textarea id="bar" />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Textarea).props().id).toBe('bar');
+  });
+
+  it('should apply the name attribute to <Textarea />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Textarea />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Textarea).props().name).toBe('foo');
+  });
+
+  it('should preserve custom name on <Textarea />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Textarea name="bar" />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Textarea).props().name).toBe('bar');
+  });
+
+  //
+
+  it('should apply the id attribute to <Select />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Select />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Select).props().id).toBe('foo');
+  });
+
+  it('should preserve custom id on <Select />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Select id="bar" />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Select).props().id).toBe('bar');
+  });
+
+  it('should apply the name attribute to <Select />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Select />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Select).props().name).toBe('foo');
+  });
+
+  it('should preserve custom name on <Select />', () => {
+    const wrapper = shallow(
+      <Raw nameAs="foo">
+        <Select name="bar" />
+      </Raw>,
+    );
+
+    expect(wrapper.find(Select).props().name).toBe('bar');
+  });
+});

--- a/src/components/__tests__/__snapshots__/Field.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Field.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  margin-bottom: 1rem;
+}
+
+.c0 .sc-bdVaJa {
+  -webkit-flex: 0 1 100px;
+  -ms-flex: 0 1 100px;
+  flex: 0 1 100px;
+  max-width: 200px;
+}
+
+.c0 .sc-bwzfXH,
+.c0 .sc-htpNat,
+.c0 .sc-ifAKCX {
+  width: 100%;
+}
+
+<div
+  className="c0"
+/>
+`;
+
+exports[`should render as stack 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.c0 .sc-bwzfXH,
+.c0 .sc-htpNat,
+.c0 .sc-ifAKCX {
+  width: 100%;
+}
+
+<div
+  className="c0"
+/>
+`;

--- a/src/pages/careers.js
+++ b/src/pages/careers.js
@@ -33,9 +33,9 @@ const Careers = () => (
       <input type="hidden" name="form-name" value="careers" />
       <fieldset>
         <Type3>Personal Information</Type3>
-        <Field>
-          <Label htmlFor="name">Name</Label>
-          <Input id="name" />
+        <Field nameAs="name">
+          <Label>Name</Label>
+          <Input />
         </Field>
       </fieldset>
 

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -36,29 +36,29 @@ const Contact = () => (
 
     <form name="contact" method="POST" data-netlify>
       <input type="hidden" name="form-name" value="contact" />
-      <Field>
-        <Label htmlFor="name">Name</Label>
-        <Input id="name" />
+      <Field nameAs="name">
+        <Label>Name</Label>
+        <Input />
       </Field>
-      <Field>
-        <Label htmlFor="company">Company</Label>
-        <Input id="company" />
+      <Field nameAs="company">
+        <Label>Company</Label>
+        <Input />
       </Field>
-      <Field>
-        <Label htmlFor="phone">Phone</Label>
-        <Input id="phone" type="phone" />
+      <Field nameAs="phone">
+        <Label>Phone</Label>
+        <Input />
       </Field>
-      <Field>
-        <Label htmlFor="fax">Fax</Label>
-        <Input id="fax" type="phone" />
+      <Field nameAs="fax">
+        <Label>Fax</Label>
+        <Input />
       </Field>
-      <Field>
-        <Label htmlFor="email">Email</Label>
-        <Input id="email" type="email" />
+      <Field nameAs="email">
+        <Label>Email</Label>
+        <Input />
       </Field>
-      <Field stack>
-        <Label htmlFor="comments">Additional comments</Label>
-        <Textarea id="comments" />
+      <Field stack nameAs="comments">
+        <Label>Additional comments</Label>
+        <Textarea />
       </Field>
       <Button type="submit">Submit</Button>
     </form>


### PR DESCRIPTION
* Set `'function-paren-newline': 'off',`
* Add logic to `Field` component so if you specify `nameAs` prop, it will set the `htmlFor` prop to any `Label` and `id` and `name` to any `Input`, `Select`, or `Textarea`.